### PR TITLE
[CHRP-49] : add unit tests with coverage reporting to Backend

### DIFF
--- a/systems/backend/chaterp-server-tests/.config/dotnet-tools.json
+++ b/systems/backend/chaterp-server-tests/.config/dotnet-tools.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "test-clean": {
+      "version": "1.0.0",
+      "commands": [
+        "test-clean"
+      ],
+      "rollForward": false
+    },
+    "test-coverage": {
+      "version": "1.0.0",
+      "commands": [
+        "test-coverage"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/systems/backend/chaterp-server-tests/NuGet.config
+++ b/systems/backend/chaterp-server-tests/NuGet.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<add key="LocalPackages" value="nupkg" />
+		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+	</packageSources>
+</configuration>

--- a/systems/backend/chaterp-server-tests/chaterp-server-tests.csproj
+++ b/systems/backend/chaterp-server-tests/chaterp-server-tests.csproj
@@ -1,0 +1,29 @@
+﻿<!-- systems/backend/chaterp-server-tests/chaterp-server-tests.csproj -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\chaterp-server\chaterp-server.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Remove="tools\test-coverage\**\*.cs" />
+		<Compile Remove="tools\test-clean\**\*.cs" />
+	</ItemGroup>
+
+</Project>

--- a/systems/backend/chaterp-server-tests/coverage-report/couverture-tests-backend.md
+++ b/systems/backend/chaterp-server-tests/coverage-report/couverture-tests-backend.md
@@ -1,0 +1,135 @@
+﻿# 📊 ChatERP - Couverture des tests Backend
+
+Ce guide explique comment **préparer l’environnement**, **nettoyer les anciens rapports**, **lancer les tests avec couverture**, et **générer un rapport HTML interactif** pour le système `Backend`.
+
+---
+
+## ⚙️ 1. Préparer l’environnement de test
+
+### 📁 Positionnement requis :  
+
+Toutes les commandes doivent être exécutées depuis le dossier **`chaterp-server-tests`**, situé dans `ChatERP/systems/backend/` :  
+
+- Terminal :  
+~~~
+cd ChatERP/systems/backend/chaterp-server-tests
+~~~
+
+### ✅ Installer les dépendances ASP.NET
+
+Assure-toi que .NET 8 est installé, puis installe les dépendances :
+
+- Terminal :  
+~~~
+dotnet restore
+~~~
+
+### ✅ Installer l’outil CLI personnalisé `dotnet test-coverage`
+
+Le projet inclut un outil CLI personnalisé situé dans `tools/test-coverage/`.
+
+La commande suivante installe localement la commande personnalisée `dotnet test-coverage` :
+
+- Terminal :  
+~~~
+dotnet tool restore
+~~~
+
+---
+
+## 🧹 2. Nettoyer les anciens rapports de couverture
+
+Avant de lancer de nouveaux tests, tu peux supprimer les anciens rapports pour éviter toute confusion :
+
+- Terminal :
+~~~
+dotnet test-clean
+~~~
+
+Cette commande supprime les dossiers `coverage-report/coverage/` et `TestResults/`.
+
+---
+
+## 🧪 3. Lancer les tests avec couverture et générer le rapport HTML
+
+Utilise la commande suivante pour exécuter les tests avec génération automatique du rapport :
+
+- Terminal :  
+~~~
+dotnet test-coverage
+~~~
+
+Cette commande :
+
+- Exécute tous les tests définis dans `tests/`, avec collecte de couverture (`--collect:"XPlat Code Coverage"`).  
+- Calcule la couverture du dossier `backend/chaterp-server/src/`, et génère le fichier `coverage.cobertura.xml` dans `TestResults/`.  
+- Génère un rapport HTML dans `coverage-report/coverage/index.html`, à l'aide du script `generate-coverage-report.ps1`, situé dans `scripts/`.  
+- Affiche un résumé de la couverture dans le terminal.
+
+---
+
+### 🔁 Alternative : exécution manuelle (sans utiliser `dotnet test-coverage`)
+
+#### Étape A : Lancer les tests avec couverture
+
+- Terminal :  
+~~~
+dotnet test --collect:"XPlat Code Coverage" --results-directory TestResults
+~~~
+
+#### Étape B : Générer le rapport HTML
+
+- Terminal :  
+~~~
+powershell -ExecutionPolicy Bypass -File ./scripts/generate-coverage-report.ps1
+~~~
+
+---
+
+## 🌐 4. Consulter le rapport HTML
+
+Ouvre le fichier `coverage-report/coverage/index.html` dans un navigateur web (double-clic ou via "Ouvrir avec...").
+
+Ce rapport interactif permet de :
+
+- Visualiser la couverture par fichier, module et ligne.  
+- Identifier les portions de code non testées.
+
+---
+
+## 📁 5. Structure du dossier `coverage-report/`
+
+~~~
+coverage-report/
+├── coverage/                       # Rapport HTML généré
+│   ├── index.html                  # Page principale du rapport
+│   └── ...                         # Fichiers HTML, JS, assets, etc.
+├── couverture-tests-backend.md     # Ce document versionné
+~~~
+
+---
+
+## 🔒 6. Git – Gestion du dossier de couverture
+
+Seul le dossier **`coverage`**, situé dans `coverage-report/`, est ignoré dans Git via `.gitignore` afin de :
+
+- Conserver le fichier `couverture-tests-backend.md` versionné.  
+- Éviter de versionner les fichiers générés automatiquement et volumineux (HTML, assets...).
+
+---
+
+## ✅ 7. Bonnes pratiques & automatisation
+
+- Maintenir une couverture de tests ≥ 90 %.  
+- Ajouter l'exécution automatique des tests dans le pipeline Docker/Docker Compose.  
+- Intégrer l'automatisation dans les pipelines CI/CD (GitHub Actions, Azure DevOps...).  
+- Utiliser un badge dans le README pour suivre la couverture.
+
+---
+
+## 📚 8. Références utiles
+
+- [ReportGenerator – GitHub](https://github.com/danielpalme/ReportGenerator)  
+- Configuration : `chaterp-server-tests.csproj`, `coverlet.runsettings`, `.config/dotnet-tools.json`  
+- Code source : `backend/chaterp-server/src`  
+- Tests unitaires : `backend/chaterp-server-tests/tests`

--- a/systems/backend/chaterp-server-tests/coverlet.runsettings
+++ b/systems/backend/chaterp-server-tests/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+	<DataCollectionRunSettings>
+		<DataCollectors>
+			<DataCollector friendlyName="XPlat Code Coverage">
+				<Configuration>
+					<Format>cobertura</Format>
+					<Include>[chaterp-server]*</Include>
+				</Configuration>
+			</DataCollector>
+		</DataCollectors>
+	</DataCollectionRunSettings>
+</RunSettings>

--- a/systems/backend/chaterp-server-tests/scripts/clean-coverage-report.ps1
+++ b/systems/backend/chaterp-server-tests/scripts/clean-coverage-report.ps1
@@ -1,0 +1,47 @@
+﻿# systems/backend/chaterp-server-tests/scripts/clean-coverage-report.ps1
+
+# 🧹 Script pour nettoyer les dossiers et fichiers de couverture de tests backend
+#
+# 📁 Emplacements nettoyés :
+#    - systems/backend/chaterp-server-tests/coverage-report/coverage/
+#    - systems/backend/chaterp-server-tests/TestResults/
+#
+# ▶️ Exemple d'exécution depuis le dossier de test :
+# PS C:\Code\ChatERP\systems\backend\chaterp-server-tests> powershell.exe -ExecutionPolicy Bypass -File ./scripts/clean-coverage-report.ps1
+
+param (
+    [string]$CoverageDir = "coverage-report/coverage",
+    [string]$TestResultsDir = "TestResults"
+)
+
+# Forcer l'encodage UTF8 pour la sortie console (Windows PowerShell)
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = New-Object -typename System.Text.UTF8Encoding
+
+$ErrorActionPreference = "Stop"
+
+try {
+    Write-Host "`n📂 Suppression des répertoires suivants :"
+    Write-Host "   - $CoverageDir"
+    Write-Host "   - $TestResultsDir"
+
+    if (Test-Path $CoverageDir) {
+        Remove-Item -Recurse -Force $CoverageDir
+        Write-Host "`n✔  Dossier supprimé : $CoverageDir"
+    } else {
+        Write-Host "`nℹ  Dossier introuvable : $CoverageDir"
+    }
+
+    if (Test-Path $TestResultsDir) {
+        Remove-Item -Recurse -Force $TestResultsDir
+        Write-Host "✔  Dossier supprimé : $TestResultsDir"
+    } else {
+        Write-Host "ℹ  Dossier introuvable : $TestResultsDir"
+    }
+
+    Write-Host "`n✅ Script terminé : tous les répertoires ciblés ont été traités.`n"
+}
+catch {
+    Write-Error "`n❌ Une erreur s’est produite lors du nettoyage : $_`n"
+    exit 1
+}

--- a/systems/backend/chaterp-server-tests/scripts/generate-coverage-report.ps1
+++ b/systems/backend/chaterp-server-tests/scripts/generate-coverage-report.ps1
@@ -1,0 +1,67 @@
+﻿# systems/backend/chaterp-server-tests/scripts/generate-coverage-report.ps1
+
+# 🚀 Script pour générer un rapport HTML de couverture de tests backend
+#
+# 💡 Ce script peut être exécuté tel quel si `reportgenerator` est installé.
+#
+# 📁 Emplacement de sortie : systems/backend/chaterp-server-tests/coverage-report/coverage/
+#
+# ▶️ Exemple d'exécution depuis le dossier de test :
+# PS C:\Code\ChatERP\systems\backend\chaterp-server-tests> powershell.exe -ExecutionPolicy Bypass -File ./scripts/generate-coverage-report.ps1
+#
+# 📦 Prérequis :
+#   - Installer reportgenerator via : `dotnet tool install -g dotnet-reportgenerator-globaltool`
+#   - S'assurer que le dossier ~/.dotnet/tools est dans votre PATH
+
+param (
+    [string]$OutputDir = "coverage-report/coverage"
+)
+
+# Forcer l'encodage UTF8 pour la sortie console (Windows PowerShell)
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = New-Object -typename System.Text.UTF8Encoding
+
+$ErrorActionPreference = "Stop"
+
+try {
+    Write-Host "`n🚀 Lancement de la génération du rapport de couverture.`n"
+
+    $reportGeneratorCmd = "reportgenerator"
+    $inputPattern = "TestResults/**/coverage.cobertura.xml"
+
+    if (-not (Get-Command $reportGeneratorCmd -ErrorAction SilentlyContinue)) {
+        Write-Error "❌ 'reportgenerator' n'est pas disponible dans le PATH.`n"
+        Write-Host "➡ Veuillez l’installer avec : dotnet tool install -g dotnet-reportgenerator-globaltool`n"
+        exit 1
+    }
+
+    $files = Get-ChildItem -Path "TestResults" -Filter "coverage.cobertura.xml" -Recurse
+    if ($files.Count -eq 0) {
+        Write-Error "❌ Aucun fichier coverage.cobertura.xml trouvé dans TestResults.`n"
+        exit 1
+    }
+
+    if (!(Test-Path $OutputDir)) {
+        New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+    }
+
+    Write-Host "⏱️ Génération en cours...`n"
+
+    & $reportGeneratorCmd `
+        "-reports:$inputPattern" `
+        "-targetdir:$OutputDir" `
+        "-reporttypes:Html" `
+        "-verbosity:Error" `
+        "-assemblyfilters:+chaterp-server"
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "❌ reportgenerator a échoué avec le code $LASTEXITCODE.`n"
+        exit $LASTEXITCODE
+    }
+
+    Write-Host "✅ Rapport HTML généré : '$OutputDir/index.html'`n"
+}
+catch {
+    Write-Error "❌ Une erreur s’est produite lors de la génération du rapport : $_`n"
+    exit 1
+}

--- a/systems/backend/chaterp-server-tests/scripts/update-test-clean-tool.ps1
+++ b/systems/backend/chaterp-server-tests/scripts/update-test-clean-tool.ps1
@@ -1,0 +1,45 @@
+﻿# systems/backend/chaterp-server-tests/scripts/update-test-clean-tool.ps1
+
+# 🔄 Script : update-test-clean-tool.ps1
+# 🔧 Mise à jour locale de l’outil CLI `test-clean`
+#
+# Ce script effectue les opérations suivantes :
+# 1. Supprime le cache NuGet global de l’outil s’il existe
+# 2. Repack le projet .NET en un nouveau `.nupkg`
+# 3. Désinstalle l’outil localement
+# 4. Réinstalle l’outil depuis le dossier `./nupkg`
+#
+# ▶️ Exemple d'exécution depuis le dossier de test :
+# PS C:\Code\ChatERP\systems\backend\chaterp-server-tests> powershell.exe -ExecutionPolicy Bypass -File ./scripts/update-test-clean-tool.ps1
+#
+# 🧪 Utilisation typique après modification du code de l’outil sans changement de version
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "`n🔄 Mise à jour de l'outil CLI 'test-clean'...`n"
+
+# 🔍 Étape 1 : Supprimer le cache NuGet global de l’outil s’il existe
+$nugetCache = Join-Path $env:USERPROFILE ".nuget\packages\test-clean"
+if (Test-Path $nugetCache) {
+    Write-Host "🧹 Suppression du cache NuGet global : $nugetCache`n"
+    Remove-Item -Recurse -Force $nugetCache
+} else {
+    Write-Host "✅ Aucun cache NuGet global à supprimer.`n"
+}
+
+# 📦 Étape 2 : Repack du projet outil en fichier .nupkg
+$toolProjectPath = "tools/test-clean"
+$nupkgOutputPath = "nupkg"
+Write-Host "📦 Packaging de l’outil dans '$nupkgOutputPath'...`n"
+dotnet pack $toolProjectPath --output $nupkgOutputPath | Out-Null
+
+# 🧽 Étape 3 : Désinstallation de la version locale existante
+Write-Host "🧽 Suppression de l’outil CLI existant (si présent)...`n"
+dotnet tool uninstall test-clean | Out-Null
+
+# 📥 Étape 4 : Réinstallation de l’outil depuis le dossier ./nupkg
+Write-Host "📥 Réinstallation de l’outil CLI depuis './nupkg'...`n"
+dotnet tool install test-clean --add-source ./nupkg | Out-Null
+
+Write-Host "✅ Mise à jour terminée avec succès !`n"
+Write-Host "🚀 Tu peux maintenant exécuter : dotnet test-clean`n"

--- a/systems/backend/chaterp-server-tests/scripts/update-test-coverage-tool.ps1
+++ b/systems/backend/chaterp-server-tests/scripts/update-test-coverage-tool.ps1
@@ -1,0 +1,45 @@
+﻿# systems/backend/chaterp-server-tests/scripts/update-test-coverage-tool.ps1
+
+# 🔄 Script : update-test-coverage-tool.ps1
+# 🔧 Mise à jour locale de l’outil CLI `test-coverage`
+#
+# Ce script effectue les opérations suivantes :
+# 1. Supprime le cache NuGet global de l’outil s’il existe
+# 2. Repack le projet .NET en un nouveau `.nupkg`
+# 3. Désinstalle l’outil localement
+# 4. Réinstalle l’outil depuis le dossier `./nupkg`
+#
+# ▶️ Exemple d'exécution depuis le dossier de test :
+# PS C:\Code\ChatERP\systems\backend\chaterp-server-tests> powershell.exe -ExecutionPolicy Bypass -File ./scripts/update-test-coverage-tool.ps1
+#
+# 🧪 Utilisation typique après modification du code de l’outil sans changement de version
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "`n🔄 Mise à jour de l'outil CLI 'test-coverage'...`n"
+
+# 🔍 Étape 1 : Supprimer le cache NuGet global de l’outil s’il existe (Nécessaire pour forcer la mise à jour)
+$nugetCache = Join-Path $env:USERPROFILE ".nuget\packages\test-coverage"
+if (Test-Path $nugetCache) {
+    Write-Host "🧹 Suppression du cache NuGet global : $nugetCache`n"
+    Remove-Item -Recurse -Force $nugetCache
+} else {
+    Write-Host "✅ Aucun cache NuGet global à supprimer.`n"
+}
+
+# 📦 Étape 2 : Repack du projet outil en fichier .nupkg
+$toolProjectPath = "tools/test-coverage"
+$nupkgOutputPath = "nupkg"
+Write-Host "📦 Packaging de l’outil dans '$nupkgOutputPath'...`n"
+dotnet pack $toolProjectPath --output $nupkgOutputPath | Out-Null
+
+# 🧽 Étape 3 : Désinstallation de la version locale existante
+Write-Host "🧽 Suppression de l’outil CLI existant (si présent)...`n"
+dotnet tool uninstall test-coverage | Out-Null
+
+# 📥 Étape 4 : Réinstallation de l’outil depuis le dossier ./nupkg
+Write-Host "📥 Réinstallation de l’outil CLI depuis './nupkg'...`n"
+dotnet tool install test-coverage --add-source ./nupkg | Out-Null
+
+Write-Host "✅ Mise à jour terminée avec succès !`n"
+Write-Host "🚀 Tu peux maintenant exécuter : dotnet test-coverage`n"

--- a/systems/backend/chaterp-server-tests/tests/AssemblyInfo.cs
+++ b/systems/backend/chaterp-server-tests/tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// systems/backend/chaterp-server-tests/tests/AssemblyInfo.cs
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/systems/backend/chaterp-server-tests/tests/Clients/README.md
+++ b/systems/backend/chaterp-server-tests/tests/Clients/README.md
@@ -1,0 +1,7 @@
+﻿# Dossier Clients — Tests unitaires
+
+Ce dossier est dédié aux tests unitaires des classes **Clients** du système Backend de ChatERP.
+
+Il sert à garantir la fiabilité et la qualité du code lié à la gestion des clients.
+
+> **Note:** Les fichiers de tests seront ajoutés dans les prochaines phases de développement.

--- a/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC01b.cs
+++ b/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC01b.cs
@@ -1,0 +1,147 @@
+﻿// systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC01b.cs
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using src.Controllers;
+using src.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace tests.Controllers
+{
+    public class EmployeesControllerTestsUC01b
+    {
+        private readonly Mock<IEmployeeService> _mockService;
+        private readonly EmployeesController _controller;
+        private const string FILENAME = "EmployeesController.Tests.UC01b.cs";
+
+        public EmployeesControllerTestsUC01b()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+            _mockService = new Mock<IEmployeeService>();
+            _controller = new EmployeesController(_mockService.Object);
+        }
+
+        private void PrintTestStart(string testName)
+        {
+            Console.WriteLine("====================================================================");
+            Console.WriteLine($"Début test - {testName}");
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"📄  File : {FILENAME}");
+        }
+
+        private void PrintTestEnd(string testName)
+        {
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"Fin test - {testName}");
+            Console.WriteLine("====================================================================");
+        }
+
+        private IFormFile CreateFakeFile(string fileName = "photo.jpg", string contentType = "image/jpeg")
+        {
+            var content = new byte[] { 1, 2, 3, 4 };
+            var stream = new MemoryStream(content);
+            return new FormFile(stream, 0, content.Length, "file", fileName)
+            {
+                Headers = new HeaderDictionary(),
+                ContentType = contentType
+            };
+        }
+
+        [Fact(DisplayName = "Succès du téléversement d’une photo")]
+        public async Task UploadEmployeePhotoAsync_ReturnsOk_WhenSuccessful()
+        {
+            string testName = "Succès du téléversement d’une photo";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : UploadEmployeePhotoAsync_ReturnsOk_WhenSuccessful");
+
+            var mockFile = CreateFakeFile();
+            var mockUrl = "https://storage.mock.com/photo.jpg";
+
+            _mockService
+                .Setup(s => s.UploadEmployeePhotoAsync(mockFile))
+                .ReturnsAsync((true, mockUrl, Array.Empty<string>()));
+
+            var result = await _controller.UploadEmployeePhotoAsync(mockFile);
+            var okResult = Assert.IsType<OkObjectResult>(result);
+
+            var json = JsonSerializer.Serialize(okResult.Value);
+            using var doc = JsonDocument.Parse(json);
+
+            var expectedUrl = mockUrl;
+            var returnedUrl = doc.RootElement.GetProperty("storageUrl").GetString();
+
+            Console.WriteLine($"Résultat attendu : storageUrl = '{expectedUrl}'");
+            Console.WriteLine($"Résultat reçu    : storageUrl = '{returnedUrl}'");
+            Console.WriteLine($"État du test     : {(returnedUrl == expectedUrl ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+
+        [Fact(DisplayName = "Fichier vide ou invalide lors du téléversement")]
+        public async Task UploadEmployeePhotoAsync_ReturnsBadRequest_WhenFileIsInvalid()
+        {
+            string testName = "Fichier vide ou invalide lors du téléversement";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : UploadEmployeePhotoAsync_ReturnsBadRequest_WhenFileIsInvalid");
+
+            IFormFile mockFile = null;
+            var mockErrors = new[] { "mockErrors - Aucun fichier reçu ou fichier vide." };
+
+            _mockService
+                .Setup(s => s.UploadEmployeePhotoAsync(null))
+                .ReturnsAsync((false, null, mockErrors));
+
+            var result = await _controller.UploadEmployeePhotoAsync(mockFile);
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+
+            var json = JsonSerializer.Serialize(badRequest.Value);
+            using var doc = JsonDocument.Parse(json);
+            var errorsArray = doc.RootElement.GetProperty("errors").EnumerateArray();
+
+            var expectedErrors = mockErrors;
+            var returnedErrors = errorsArray.Select(e => e.GetString()).ToArray();
+
+            Console.WriteLine($"Résultat attendu : [{string.Join(", ", expectedErrors)}]");
+            Console.WriteLine($"Résultat reçu    : [{string.Join(", ", returnedErrors)}]");
+            Console.WriteLine($"État du test     : {(returnedErrors.Length == expectedErrors.Length && !expectedErrors.Except(returnedErrors).Any() ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+
+        [Fact(DisplayName = "Exception levée lors du téléversement")]
+        public async Task UploadEmployeePhotoAsync_ThrowsException_WhenServiceFails()
+        {
+            string testName = "Exception levée lors du téléversement";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : UploadEmployeePhotoAsync_ThrowsException_WhenServiceFails");
+
+            var file = CreateFakeFile();
+            var mockMessage = "mockMessage - Erreur inattendue";
+
+            _mockService
+                .Setup(s => s.UploadEmployeePhotoAsync(file))
+                .ThrowsAsync(new Exception(mockMessage));
+
+            var exception = await Assert.ThrowsAsync<Exception>(() =>
+                _controller.UploadEmployeePhotoAsync(file));
+
+            var expectedMessage = mockMessage;
+            var returnedMessage = exception.Message;
+
+            Console.WriteLine($"Résultat attendu : {expectedMessage}");
+            Console.WriteLine($"Résultat reçu    : {returnedMessage}");
+            Console.WriteLine($"État du test     : {(returnedMessage == expectedMessage ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+    }
+}

--- a/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC02a.cs
+++ b/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC02a.cs
@@ -1,0 +1,157 @@
+﻿// systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC02a.cs
+
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using src.Controllers;
+using src.DTOs;
+using src.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace tests.Controllers
+{
+    public class EmployeesControllerTestsUC02a
+    {
+        private readonly Mock<IEmployeeService> _mockService;
+        private readonly EmployeesController _controller;
+        private const string FILENAME = "EmployeesController.Tests.UC02a.cs";
+
+        public EmployeesControllerTestsUC02a()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+            _mockService = new Mock<IEmployeeService>();
+            _controller = new EmployeesController(_mockService.Object);
+        }
+
+        private void PrintTestStart(string testName)
+        {
+            Console.WriteLine("====================================================================");
+            Console.WriteLine($"Début test - {testName}");
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"📄  File : {FILENAME}");
+        }
+
+        private void PrintTestEnd(string testName)
+        {
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"Fin test - {testName}");
+            Console.WriteLine("====================================================================");
+        }
+
+        [Fact(DisplayName = "Succès de la consultation de tous les employés")]
+        public async Task GetAllEmployeesAsync_ReturnsEmployeeList_WhenSuccessful()
+        {
+            string testName = "Succès de la consultation de tous les employés";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : GetAllEmployeesAsync_ReturnsEmployeeList_WhenSuccessful");
+
+            var mockEmployees = new List<EmployeeWithId>
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "Alice Martin",
+                    Role = "Développeuse",
+                    Email = "alice@example.com",
+                    Phone = "514-123-4567",
+                    Address = "123 rue Principale, Montréal",
+                    Department = "TI",
+                    Manager = "Jean Dupuis",
+                    Status = "Actif",
+                    HireDate = "2023-01-15",
+                    PhotoUrl = "https://example.com/photos/alice.jpg"
+                },
+                new()
+                {
+                    Id = 2,
+                    Name = "Bob",
+                    Role = "Designer",
+                    Email = "bob@example.com",
+                    Phone = "514-987-6543",
+                    Address = "456 avenue des Arts, Montréal",
+                    Department = "Marketing",
+                    Manager = "Julie Tremblay",
+                    Status = "Actif",
+                    HireDate = "2022-08-01",
+                    PhotoUrl = "https://example.com/photos/bob.jpg"
+                }
+            };
+
+            _mockService
+                .Setup(s => s.GetAllEmployeesAsync())
+                .ReturnsAsync(mockEmployees);
+
+            var result = await _controller.GetAllEmployeesAsync();
+            var okResult = Assert.IsType<ActionResult<List<EmployeeWithId>>>(result);
+
+            var expectedEmployees = mockEmployees;
+            var returnedEmployees = Assert.IsType<List<EmployeeWithId>>(okResult.Value);
+
+            Console.WriteLine($"Résultat attendu : {expectedEmployees.Count} employés");
+            Console.WriteLine($"Résultat reçu    : {returnedEmployees.Count} employés");
+
+            for(int i = 0; i < expectedEmployees.Count; i++)
+            {
+                Console.WriteLine($"  - Employé [{expectedEmployees[i].Id}] : ");
+                Console.WriteLine($"             Nom attendu : {expectedEmployees[i].Name}");
+                Console.WriteLine($"             Nom reçu : {returnedEmployees[i].Name}");
+                Console.WriteLine($"             Rôle attendu : {expectedEmployees[i].Role}");
+                Console.WriteLine($"             Rôle reçu : {returnedEmployees[i].Role}");
+                Console.WriteLine($"             Email attendu: {expectedEmployees[i].Department}");
+                Console.WriteLine($"             Email reçu : {returnedEmployees[i].Department}");
+            }
+
+            bool testPassed = returnedEmployees.Count == expectedEmployees.Count &&
+                              !expectedEmployees.Where((e, i) =>
+                                  e.Id != returnedEmployees[i].Id ||
+                                  e.Name != returnedEmployees[i].Name ||
+                                  e.Role != returnedEmployees[i].Role ||
+                                  e.Email != returnedEmployees[i].Email ||
+                                  e.Phone != returnedEmployees[i].Phone ||
+                                  e.Address != returnedEmployees[i].Address ||
+                                  e.Department != returnedEmployees[i].Department ||
+                                  e.Manager != returnedEmployees[i].Manager ||
+                                  e.Status != returnedEmployees[i].Status ||
+                                  e.HireDate != returnedEmployees[i].HireDate ||
+                                  e.PhotoUrl != returnedEmployees[i].PhotoUrl
+                              ).Any();
+
+            Console.WriteLine($"État du test     : {(testPassed ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+
+        [Fact(DisplayName = "Liste vide d’employés retournée avec succès")]
+        public async Task GetAllEmployeesAsync_ReturnsEmptyList_WhenNoEmployeesExist()
+        {
+            string testName = "Liste vide d’employés retournée avec succès";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : GetAllEmployeesAsync_ReturnsEmptyList_WhenNoEmployeesExist");
+
+            var mockEmployees = new List<EmployeeWithId>();
+
+            _mockService
+                .Setup(s => s.GetAllEmployeesAsync())
+                .ReturnsAsync(mockEmployees);
+
+            var result = await _controller.GetAllEmployeesAsync();
+            var okResult = Assert.IsType<ActionResult<List<EmployeeWithId>>>(result);
+
+            var expectedEmployees = mockEmployees;
+            var returnedEmployees = Assert.IsType<List<EmployeeWithId>>(okResult.Value);
+
+            Console.WriteLine($"Résultat attendu : {expectedEmployees.Count} employé(s)");
+            Console.WriteLine($"Résultat reçu    : {returnedEmployees.Count} employé(s)");
+
+            Assert.Empty(returnedEmployees);
+            Console.WriteLine("État du test     : Passed ✅");
+
+            PrintTestEnd(testName);
+        }
+    }
+}

--- a/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC02b.cs
+++ b/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC02b.cs
@@ -1,0 +1,148 @@
+﻿// systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC02b.cs
+
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using src.Controllers;
+using src.DTOs;
+using src.Services;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace tests.Controllers
+{
+    public class EmployeesControllerTestsUC02b
+    {
+        private readonly Mock<IEmployeeService> _mockService;
+        private readonly EmployeesController _controller;
+        private const string FILENAME = "EmployeesController.Tests.UC02b.cs";
+
+        public EmployeesControllerTestsUC02b()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+            _mockService = new Mock<IEmployeeService>();
+            _controller = new EmployeesController(_mockService.Object);
+        }
+
+        private void PrintTestStart(string testName)
+        {
+            Console.WriteLine("====================================================================");
+            Console.WriteLine($"Début test - {testName}");
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"📄  File : {FILENAME}");
+        }
+
+        private void PrintTestEnd(string testName)
+        {
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"Fin test - {testName}");
+            Console.WriteLine("====================================================================");
+        }
+
+        [Fact(DisplayName = "Employé trouvé avec succès par ID")]
+        public async Task GetEmployeeByIdAsync_ReturnsEmployee_WhenFound()
+        {
+            string testName = "Employé trouvé avec succès par ID";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : GetEmployeeByIdAsync_ReturnsEmployee_WhenFound");
+
+            int mockEmployeeId = 1;
+            var mockEmployee = new EmployeeWithId
+            {
+                Id = mockEmployeeId,
+                Name = "Alice Martin",
+                Role = "Développeuse",
+                Email = "alice@example.com",
+                Phone = "514-123-4567",
+                Address = "123 rue Principale, Montréal",
+                Department = "TI",
+                Manager = "Jean Dupuis",
+                Status = "Actif",
+                HireDate = "2023-01-15",
+                PhotoUrl = "https://example.com/photos/alice.jpg"
+            };
+
+            _mockService
+                .Setup(s => s.GetEmployeeByIdAsync(mockEmployeeId))
+                .ReturnsAsync(mockEmployee);
+
+            var result = await _controller.GetEmployeeByIdAsync(mockEmployeeId);
+            var actionResult = Assert.IsType<ActionResult<EmployeeWithId>>(result);
+
+            var expectedEmployee = mockEmployee;
+            var returnedEmployee = Assert.IsType<EmployeeWithId>(actionResult.Value);
+
+            Console.WriteLine($"ID attendu : {expectedEmployee.Id}");
+            Console.WriteLine($"ID reçu : {returnedEmployee.Id}");
+            Console.WriteLine($"Nom attendu : {expectedEmployee.Name}");
+            Console.WriteLine($"Nom reçu : {returnedEmployee.Name}");
+            Console.WriteLine($"Rôle attendu : {expectedEmployee.Role}");
+            Console.WriteLine($"Rôle reçu : {returnedEmployee.Role}");
+
+            bool testPassed =
+                returnedEmployee.Id == expectedEmployee.Id &&
+                returnedEmployee.Name == expectedEmployee.Name &&
+                returnedEmployee.Role == expectedEmployee.Role &&
+                returnedEmployee.Email == expectedEmployee.Email &&
+                returnedEmployee.Phone == expectedEmployee.Phone &&
+                returnedEmployee.Address == expectedEmployee.Address &&
+                returnedEmployee.Department == expectedEmployee.Department &&
+                returnedEmployee.Manager == expectedEmployee.Manager &&
+                returnedEmployee.Status == expectedEmployee.Status &&
+                returnedEmployee.HireDate == expectedEmployee.HireDate &&
+                returnedEmployee.PhotoUrl == expectedEmployee.PhotoUrl;
+
+            Console.WriteLine($"État du test     : {(testPassed ? "Passed ✅" : "Failed ❌")}");
+
+            Assert.True(testPassed);
+            PrintTestEnd(testName);
+        }
+
+        [Fact(DisplayName = "Employé introuvable par ID")]
+        public async Task GetEmployeeByIdAsync_ReturnsNotFound_WhenEmployeeDoesNotExist()
+        {
+            string testName = "Employé introuvable par ID";
+            PrintTestStart(testName);
+
+            Console.WriteLine("▶️  Task : GetEmployeeByIdAsync_ReturnsNotFound_WhenEmployeeDoesNotExist");
+
+            int mockEmployeeId = 999;
+
+            _mockService
+                .Setup(s => s.GetEmployeeByIdAsync(mockEmployeeId))
+                .ReturnsAsync((EmployeeWithId)null);
+
+            var result = await _controller.GetEmployeeByIdAsync(mockEmployeeId);
+            var actionResult = Assert.IsType<ActionResult<EmployeeWithId>>(result);
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(actionResult.Result);
+
+            var expectedCode = 404;
+            var returnedCode = notFoundResult.StatusCode;
+
+            var expectedMessage = $"Employé introuvable.";
+            var returnedObject = notFoundResult.Value;
+            string returnedMessage = "";
+
+            if(returnedObject is not null)
+            {
+                var props = returnedObject.GetType().GetProperty("message");
+                returnedMessage = props.GetValue(returnedObject).ToString();
+            }
+
+            Console.WriteLine($"Code HTTP attendu   : {expectedCode}");
+            Console.WriteLine($"Code HTTP reçu      : {returnedCode}");
+            Console.WriteLine($"Message attendu     : {expectedMessage}");
+            Console.WriteLine($"Message reçu        : {returnedMessage}");
+
+            bool testPassed =
+                returnedCode == expectedCode &&
+                returnedMessage == expectedMessage;
+
+            Console.WriteLine($"État du test        : {(testPassed ? "Passed ✅" : "Failed ❌")}");
+            Assert.True(testPassed);
+
+            PrintTestEnd(testName);
+        }
+    }
+}

--- a/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC03.cs
+++ b/systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC03.cs
@@ -1,0 +1,153 @@
+﻿// systems/backend/chaterp-server-tests/tests/Controllers/EmployeesController.Tests.UC03.cs
+
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using src.Controllers;
+using src.DTOs;
+using src.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace tests.Controllers
+{
+    public class EmployeesControllerTestsUC03
+    {
+        private readonly Mock<IEmployeeService> _mockService;
+        private readonly EmployeesController _controller;
+        private const string FILENAME = "EmployeesController.Tests.UC03.cs";
+
+        public EmployeesControllerTestsUC03()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+            _mockService = new Mock<IEmployeeService>();
+            _controller = new EmployeesController(_mockService.Object);
+        }
+
+        private void PrintTestStart(string testName)
+        {
+            Console.WriteLine("====================================================================");
+            Console.WriteLine($"Début test - {testName}");
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"📄  File : {FILENAME}");
+        }
+
+        private void PrintTestEnd(string testName)
+        {
+            Console.WriteLine("--------------------------------------------------------------------");
+            Console.WriteLine($"Fin test - {testName}");
+            Console.WriteLine("====================================================================");
+        }
+
+        private EmployeeData GetSampleEmployee() => new EmployeeData
+        {
+            Name = "Jane Smith",
+            Email = "jane@example.com",
+            Role = "Designer",
+            Phone = "7654321",
+            Address = "456 avenue secondaire",
+            Department = "Design",
+            Manager = "Dwight",
+            Status = "Actif",
+            HireDate = "2022-06-15",
+            PhotoUrl = "http://url/photo2.jpg"
+        };
+
+        [Fact(DisplayName = "Succès de la mise à jour d’un employé")]
+        public async Task UpdateEmployeeAsync_ReturnsOk_WhenSuccessful()
+        {
+            string testName = "Succès de la mise à jour d’un employé";
+            PrintTestStart(testName);
+
+            Console.WriteLine($"▶️  Task : UpdateEmployeeAsync_ReturnsOk_WhenSuccessful");
+
+            var mockEmployee = GetSampleEmployee();
+            var mockEmployeeId = 2;
+
+            _mockService
+                .Setup(s => s.UpdateEmployeeAsync(mockEmployeeId, mockEmployee))
+                .ReturnsAsync((true, Array.Empty<string>()));
+
+            var result = await _controller.UpdateEmployeeAsync(mockEmployeeId, mockEmployee);
+            var okResult = Assert.IsType<OkObjectResult>(result);
+
+            var json = JsonSerializer.Serialize(okResult.Value);
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+
+            var expectedMessage = "Employé mis à jour avec succès.";
+            var returnedMessage = root.GetProperty("message").GetString();
+
+            Console.WriteLine($"Résultat attendu : message = '{expectedMessage}'");
+            Console.WriteLine($"Résultat reçu    : message = '{returnedMessage}'");
+            Console.WriteLine($"État du test     : {(expectedMessage == returnedMessage ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+
+        [Fact(DisplayName = "Échec de validation lors de la mise à jour")]
+        public async Task UpdateEmployeeAsync_ReturnsBadRequest_WhenValidationFails()
+        {
+            string testName = "Échec de validation lors de la mise à jour";
+            PrintTestStart(testName);
+
+            Console.WriteLine($"▶️  Task : UpdateEmployeeAsync_ReturnsBadRequest_WhenValidationFails");
+
+            var mockEmployee = GetSampleEmployee();
+            var mockEmployeeId = 2;
+            var mockErrors = new[] { "mockErrors - Le rôle est requis.", "Adresse invalide." };
+
+            _mockService
+                .Setup(s => s.UpdateEmployeeAsync(mockEmployeeId, mockEmployee))
+                .ReturnsAsync((false, mockErrors));
+
+            var result = await _controller.UpdateEmployeeAsync(mockEmployeeId, mockEmployee);
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+
+            var json = JsonSerializer.Serialize(badRequestResult.Value);
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+
+            var expectedErrors = mockErrors;
+            var returnedErrors = root.GetProperty("errors").EnumerateArray().Select(e => e.GetString()).ToList();
+
+            Console.WriteLine($"Résultat attendu : [{string.Join(", ", expectedErrors)}]");
+            Console.WriteLine($"Résultat reçu    : [{string.Join(", ", returnedErrors)}]");
+            Console.WriteLine($"État du test     : {(returnedErrors.Count == expectedErrors.Length && !expectedErrors.Except(returnedErrors).Any() ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+
+        [Fact(DisplayName = "Exception levée lors de la mise à jour")]
+        public async Task UpdateEmployeeAsync_ThrowsException_WhenServiceFails()
+        {
+            string testName = "Exception levée lors de la mise à jour";
+            PrintTestStart(testName);
+
+            Console.WriteLine($"▶️  Task : UpdateEmployeeAsync_ThrowsException_WhenServiceFails");
+
+            var mockEmployee = GetSampleEmployee();
+            var mockEmployeeId = 2;
+            var mockMessage = "mockMessage - Erreur serveur lors de la mise à jour";
+
+            _mockService
+                .Setup(s => s.UpdateEmployeeAsync(mockEmployeeId, mockEmployee))
+                .ThrowsAsync(new Exception(mockMessage));
+
+            var exception = await Assert.ThrowsAsync<Exception>(() =>
+                _controller.UpdateEmployeeAsync(mockEmployeeId, mockEmployee));
+
+            var expectedMessage = mockMessage;
+            var returnedMessage = exception.Message;
+
+            Console.WriteLine($"Résultat attendu : {expectedMessage}");
+            Console.WriteLine($"Résultat reçu    : {returnedMessage}");
+            Console.WriteLine($"État du test     : {(returnedMessage == expectedMessage ? "Passed ✅" : "Failed ❌")}");
+
+            PrintTestEnd(testName);
+        }
+    }
+}

--- a/systems/backend/chaterp-server-tests/tests/Services/README.md
+++ b/systems/backend/chaterp-server-tests/tests/Services/README.md
@@ -1,0 +1,7 @@
+﻿# Dossier Services — Tests unitaires
+
+Ce dossier est dédié aux tests unitaires des classes **Services** du système Backend de ChatERP.
+
+Il sert à garantir la fiabilité et la qualité du code lié à la gestion des services métiers.
+
+> **Note:** Les fichiers de tests seront ajoutés dans les prochaines phases de développement.

--- a/systems/backend/chaterp-server-tests/tools/test-clean/Program.cs
+++ b/systems/backend/chaterp-server-tests/tools/test-clean/Program.cs
@@ -1,0 +1,61 @@
+﻿// systems/backend/chaterp-server-tests/tools/test-clean/Program.cs
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        string currentDir = Directory.GetCurrentDirectory();
+
+        if (currentDir.Contains(@"\.nuget\packages", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.Error.WriteLine("\n❌ Cet outil ne doit pas être exécuté depuis le cache NuGet global.");
+            Console.Error.WriteLine("\n💡 Utilise la version locale via 'dotnet tool run test-clean' depuis chaterp-server-tests.");
+            Environment.Exit(1);
+        }
+
+        string cleanScript = Path.Combine(currentDir, "scripts", "clean-coverage-report.ps1");
+
+        if (!File.Exists(cleanScript))
+        {
+            Console.Error.WriteLine($"\n❌ Script introuvable : {cleanScript}");
+            Environment.Exit(1);
+        }
+
+        Console.WriteLine("\n🧹 Initialisation du nettoyage des anciens fichiers de couverture...");
+
+        var psProcess = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "powershell",
+                Arguments = $"-ExecutionPolicy Bypass -File \"{cleanScript}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = currentDir
+            }
+        };
+
+        psProcess.OutputDataReceived += (s, e) => { if (e.Data != null) Console.WriteLine(e.Data); };
+        psProcess.ErrorDataReceived += (s, e) => { if (e.Data != null) Console.Error.WriteLine(e.Data); };
+
+        psProcess.Start();
+        psProcess.BeginOutputReadLine();
+        psProcess.BeginErrorReadLine();
+        psProcess.WaitForExit();
+
+        if (psProcess.ExitCode != 0)
+        {
+            Console.Error.WriteLine("❌ Le nettoyage a échoué (erreur interne au script).");
+            Environment.Exit(psProcess.ExitCode);
+        }
+
+        Console.WriteLine("✅ Tous les fichiers temporaires ont été correctement nettoyés.");
+    }
+}

--- a/systems/backend/chaterp-server-tests/tools/test-clean/test-clean.csproj
+++ b/systems/backend/chaterp-server-tests/tools/test-clean/test-clean.csproj
@@ -1,0 +1,13 @@
+﻿<!-- systems/backend/chaterp-server-tests/tools/test-clean/test-clean.csproj -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>test-clean</ToolCommandName>
+	</PropertyGroup>
+
+</Project>
+

--- a/systems/backend/chaterp-server-tests/tools/test-coverage/test-coverage.csproj
+++ b/systems/backend/chaterp-server-tests/tools/test-coverage/test-coverage.csproj
@@ -1,0 +1,12 @@
+<!-- systems/backend/chaterp-server-tests/tools/test-coverage/test-coverage.csproj -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>test-coverage</ToolCommandName>
+	</PropertyGroup>
+
+</Project>


### PR DESCRIPTION
# 📦 Pull Request

## Summary
- Add controllers test folder with detailed CRUD unit tests for backend
- Add services and clients test folders with documentation (README)
- Add coverage-report folder for unit tests coverage reports and configuration
- Add backend test tools, scripts, and NuGet configuration for test automation

## Checklist
- [x] Code compiles without errors
- [x] All tests pass successfully
- [x] Test coverage maintained or improved
- [x] Documentation updated where applicable
- [x] Changes comply with coding standards

## References
- Issue #49 
