### PR TITLE
[CHRP-55] : add scripts to run all unit tests

### DIFF
--- a/scripts/tests/run-all-tests.ps1
+++ b/scripts/tests/run-all-tests.ps1
@@ -1,0 +1,75 @@
+﻿# ChatERP/scripts/tests/run-all-tests.ps1
+
+# 🧪 Script PowerShell – Exécution globale des tests du projet ChatERP
+#
+# 🧭 Objectif :
+#   Exécute automatiquement l'ensemble des tests du projet ChatERP : frontend, backend et database.
+#   Le script appelle successivement les sous-scripts de test pour chaque système, et synthétise les résultats.
+#
+# ⚙️ Comportement :
+#   - Gestion des erreurs dans chaque sous-script
+#   - Affichage d’un résumé global en fin d’exécution
+#
+# 📄 Scripts invoqués :
+#   - run-frontend-tests.ps1
+#   - run-backend-tests.ps1
+#   - run-database-tests.ps1
+#
+# ✅ Résultat :
+#   - Affiche en couleur les étapes de test
+#   - Retourne un code de sortie 0 si tous les tests réussissent, 1 en cas d'échec
+#
+# ▶️ Exemple d’exécution depuis la racine du projet :
+#   PS C:\Code\ChatERP> powershell -ExecutionPolicy Bypass -File .\scripts\tests\run-all-tests.ps1
+#
+# 📝 Écrit en UTF-8 pour un affichage correct des symboles et messages multilingues
+
+
+Write-Host "`n================== 🚀 Lancement des tests ChatERP ==================`n" -ForegroundColor Cyan
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+$frontendTestsScript = Join-Path $scriptDir "run-frontend-tests.ps1"
+$backendTestsScript  = Join-Path $scriptDir "run-backend-tests.ps1"
+$databaseTestsScript = Join-Path $scriptDir "run-database-tests.ps1"
+
+$global:hasFailed = $false
+
+# 🧪 1. Tests FRONTEND
+Write-Host "`n▶️  Démarrage des tests FRONTEND`n" -ForegroundColor Yellow
+try {
+    & $frontendTestsScript
+    if ($LASTEXITCODE -ne 0) { $global:hasFailed = $true }
+} catch {
+    Write-Error "`n❌ Erreur inattendue dans le script frontend`n"
+    $global:hasFailed = $true
+}
+
+# 🧪 2. Tests BACKEND
+Write-Host "`n▶️  Démarrage des tests BACKEND`n" -ForegroundColor Yellow
+try {
+    & $backendTestsScript
+    if ($LASTEXITCODE -ne 0) { $global:hasFailed = $true }
+} catch {
+    Write-Error "`n❌ Erreur inattendue dans le script backend`n"
+    $global:hasFailed = $true
+}
+
+# 🧪 3. Tests DATABASE
+Write-Host "`n▶️  Démarrage des tests DATABASE`n" -ForegroundColor Yellow
+try {
+    & $databaseTestsScript
+    if ($LASTEXITCODE -ne 0) { $global:hasFailed = $true }
+} catch {
+    Write-Error "`n❌ Erreur inattendue dans le script database`n"
+    $global:hasFailed = $true
+}
+
+# ✅ Résultat global
+if ($global:hasFailed) {
+    Write-Host "`n================== ❌ Un ou plusieurs tests ont échoué ==================`n" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "`n================== ✅ Tous les tests ont réussi ==================`n" -ForegroundColor Green
+    exit 0
+}

--- a/scripts/tests/run-backend-tests.ps1
+++ b/scripts/tests/run-backend-tests.ps1
@@ -1,0 +1,53 @@
+﻿# ChatERP/scripts/tests/run-backend-tests.ps1
+
+# 🧪 Script PowerShell – Exécution des tests du système Backend de ChatERP
+#
+# 🧭 Objectif :
+#   Exécute automatiquement les tests unitaires et d’intégration du système Backend (.NET 8).
+#
+# 📁 Dossier contenant les tests :
+#   - systems/backend/chaterp-server-tests
+#
+# 📁 Dossier contenant le code source :
+#   - systems/database/chaterp-server
+#
+# ⚙️ Comportement :
+#   - Vérifie l’existence du dossier
+#   - Change de dossier temporairement (`Push-Location`)
+#   - Exécute les tests et gère le retour
+#   - Affiche des messages colorés pour l’état final
+#
+# ✅ Résultat :
+#   - Lance `dotnet test`
+#   - Affiche le statut des tests (succès ou échec)
+#   - Retourne le code d’erreur approprié
+#
+# ▶️ Exemple d’exécution depuis la racine du projet :
+#   PS C:\Code\ChatERP> powershell -ExecutionPolicy Bypass -File .\scripts\tests\run-backend-tests.ps1
+#
+# 📝 Écrit en UTF-8 pour un affichage correct des symboles et messages multilingues
+
+
+Write-Host "`n==================🚀 Tests Backend – Lancement ==================`n"
+
+$testPath = "systems/backend/chaterp-server-tests"
+
+if (-Not (Test-Path $testPath)) {
+    Write-Error "❌ Dossier introuvable : $testPath"
+    exit 1
+}
+
+Push-Location $testPath
+
+dotnet test
+
+$exitCode = $LASTEXITCODE
+Pop-Location
+
+if ($exitCode -ne 0) {
+    Write-Error "================== ❌ Tests Backend - Échec (code $exitCode) =================="
+    exit $exitCode
+}
+
+Write-Host "`n================== ✅ Tests Backend - Succès ==================`n"
+exit 0

--- a/scripts/tests/run-database-tests.ps1
+++ b/scripts/tests/run-database-tests.ps1
@@ -1,0 +1,62 @@
+﻿# ChatERP/scripts/tests/run-database-tests.ps1
+
+# 🧪 Script PowerShell – Exécution des tests du système Database de ChatERP
+#
+# 🧭 Objectif :
+#   Exécute automatiquement les tests unitaires et d’intégration du système Database (FastAPI + Persistence).
+#
+# 📁 Dossier contenant les tests :
+#   - systems/database/chaterp-persistence-tests
+#
+# 📁 Dossier contenant le code source :
+#   - systems/database/chaterp-persistence
+#
+# ⚙️ Comportement :
+#   - Active un environnement virtuel `.venv` si présent
+#   - Crée l’environnement virtuel et installe les dépendances (si Activate.ps1 est absent)
+#   - Lance les tests via `pytest` dans le module `chaterp-persistence-tests`
+#
+# ✅ Résultat :
+#   - Affiche un message clair selon le succès ou l’échec des tests
+#   - Retourne le code de sortie correspondant (0 = succès, ≠0 = échec)
+#
+# ▶️ Exemple d’exécution depuis la racine du projet :
+#   PS C:\Code\ChatERP> powershell -ExecutionPolicy Bypass -File .\scripts\tests\run-database-tests.ps1
+#
+# 📝 Écrit en UTF-8 pour un affichage correct des messages multilingues
+
+
+Write-Host "`n================== 🚀 Tests Database – Lancement ==================`n"
+
+$testPath = "systems/database/chaterp-persistence-tests"
+
+if (-Not (Test-Path $testPath)) {
+    Write-Error "❌ Dossier introuvable : $testPath"
+    exit 1
+}
+
+Push-Location $testPath
+
+if (-Not (Test-Path "../chaterp-persistence/.venv/Scripts/Activate.ps1")) {
+    Write-Host "⚙️ Création d’un environnement virtuel Python…"
+    Push-Location "../chaterp-persistence"
+    python -m venv .venv
+    .venv/Scripts/Activate.ps1
+    pip install -r requirements.txt
+    Pop-Location
+}
+
+.venv\Scripts\Activate.ps1
+
+pytest
+
+$exitCode = $LASTEXITCODE
+Pop-Location
+
+if ($exitCode -ne 0) {
+    Write-Error "================== ❌ Tests Database - Échec (code $exitCode) =================="
+    exit $exitCode
+}
+
+Write-Host "`n================== ✅ Tests Database - Succès ==================`n"
+exit 0

--- a/scripts/tests/run-frontend-tests.ps1
+++ b/scripts/tests/run-frontend-tests.ps1
@@ -1,0 +1,56 @@
+﻿# ChatERP/scripts/tests/run-frontend-tests.ps1
+
+# 🧪 Script PowerShell – Exécution des tests du système Frontend de ChatERP
+#
+# 🧭 Objectif :
+#   Exécute automatiquement les tests unitaires et d’intégration du système Frontend (React + Vitest).
+#
+# 📁 Dossier contenant les tests :
+#   - systems/frontend/chaterp-web-tests
+#
+# 📁 Dossier contenant le code source :
+#   - systems/database/chaterp-web
+#
+# ⚙️ Comportement :
+#   - Vérifie que le dossier des tests existe
+#   - Installe les dépendances npm si le dossier `node_modules` est absent
+#   - Lance les tests via la commande `npx vitest run`
+#
+# ✅ Résultat :
+#   - Affiche un message clair selon le succès ou l’échec des tests
+#   - Retourne le code de sortie correspondant (0 = succès, ≠0 = échec)
+#
+# ▶️ Exemple d’exécution depuis la racine du projet :
+#   PS C:\Code\ChatERP> powershell -ExecutionPolicy Bypass -File .\scripts\tests\run-frontend-tests.ps1
+#
+# 📝 Écrit en UTF-8 pour un affichage correct des messages multilingues
+
+
+Write-Host "`n================== 🚀 Tests Frontend – Lancement ==================`n"
+
+$testPath = "systems/frontend/chaterp-web-tests"
+
+if (-Not (Test-Path $testPath)) {
+    Write-Error "❌ Dossier introuvable : $testPath"
+    exit 1
+}
+
+Push-Location $testPath
+
+if (-Not (Test-Path "node_modules")) {
+    Write-Host "📦 Installation des dépendances..."
+    npm install
+}
+
+npx vitest run
+
+$exitCode = $LASTEXITCODE
+Pop-Location
+
+if ($exitCode -ne 0) {
+    Write-Error "================== ❌ Tests Frontend - Échec (code $exitCode) =================="
+    exit $exitCode
+}
+ 
+Write-Host "`n================== ✅ Tests Frontend - Succès ==================`n"
+exit 0


### PR DESCRIPTION
# 📦 Pull Request

## Summary
- Add scripts to run unit tests for Frontend, Backend, Database subsystems
- Add script to run all unit tests at once
- Place all scripts in `scripts/tests/` for centralized test automation

## Checklist
- [x] Code compiles without errors
- [x] All tests pass successfully
- [x] Test coverage maintained or improved
- [x] Documentation updated where applicable
- [x] Changes comply with coding standards

## References
- Issue #55 
